### PR TITLE
Update package name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 tt-math
 =======
-[![Build Status](https://travis-ci.org/necromant2005/tt-math.svg)](https://travis-ci.org/necromant2005/tt-math)
+[![Build Status](https://travis-ci.org/truesocialmetrics/math.svg)](https://travis-ci.org/truesocialmetrics/math)
 
 Introduction
 ------------
@@ -28,7 +28,7 @@ Installation
 
 ```json
 "require": {
-    "necromant2005/tt-math": "1.*",
+    "truesocialmetrics/math": "1.*",
 }
 ```
 


### PR DESCRIPTION
When installing this package, it has this warning:

> Package necromant2005/tt-math is abandoned, you should avoid using it. Use https://github.com/truesocialmetrics/math instead.

Looking at the alternative URL, it still references the original vendor and package name. This PR changes it to match the values on Packagist (`composer require truesocialmetrics/math`).